### PR TITLE
Update for Catalina

### DIFF
--- a/macos_usb.sh
+++ b/macos_usb.sh
@@ -32,7 +32,7 @@ function version {
 	Press Enter to download latest release (default)
 	[H]igh Sierra (10.13)
 	[M]ojave (10.14)
-	[C]atalina (10.15 beta)
+	[C]atalina (10.15)
 
 	'
 	read -n 1 -p "[H/M/C] " macOS_release_name 2>/dev/tty


### PR DESCRIPTION
Since corpnewt/gibMacOS tool updated their tool to support Catalina (the final release, not the beta), there is no point in keeping "10.15 beta" because the tools just downloads the latest 10.15, meaning that is not beta.